### PR TITLE
Fog support, Draw distance cutoff

### DIFF
--- a/LightShafts.Resources.cs
+++ b/LightShafts.Resources.cs
@@ -68,6 +68,8 @@ public partial class LightShafts : MonoBehaviour
 	LightType m_LightType = LightType.Directional;
 	bool m_DX11Support = false;
 	bool m_MinRequirements = false;
+	
+	public float m_DrawDistance = 100.0f;
 
 	void InitLUTs ()
 	{


### PR DESCRIPTION
Robert, I've added support for fog so that the lights shafts fade into it nicely. I also added a draw distance parameter to stop drawing the effect beyond a certain distance as a performance optimization. Tried to keep the changes as minimal as possible. Feel free to use any parts of it if you feel like it's useful for you :)

Log:
- Support fading into fog (all Unity fog modes supported, using shader keywords to optimize shader runtime)
- Added 'Draw distance' parameter to stop the effect from rendering after a certain distance from the camera. Hardcoded fade out at the final 10% of the range for now.
